### PR TITLE
passing on an optional argument (...) to qvalue

### DIFF
--- a/R/deSet-methods.R
+++ b/R/deSet-methods.R
@@ -52,7 +52,7 @@ setMethod("odp",
           function(object, de.fit, odp.parms = NULL, weights = NULL, bs.its = 100,
                    n.mods = 50, seed = NULL, verbose = TRUE, ...)  {
             de.fit <- fit_models(object,
-                                 stat.type = "odp", weights = weights, ...)
+                                 stat.type = "odp", weights = weights)
             results <- odp(object, de.fit,
                            odp.parms = odp.parms,
                            n.mods = n.mods,


### PR DESCRIPTION
The S4 method for signature 'deSet,missing' couldn't pass on ... to qvalue